### PR TITLE
Optmization in LilUCB

### DIFF
--- a/trial.txt
+++ b/trial.txt
@@ -1,5 +1,0 @@
-before:
-    INFO:absl:start Exponential-Gap Elimination's play with multi_armed_bandit
-    INFO:absl:Exponential-Gap Elimination's play with multi_armed_bandit runs 36.91 seconds.
-    INFO:absl:start Heuristic lilUCB's play with multi_armed_bandit
-    INFO:absl:Heuristic lilUCB's play with multi_armed_bandit runs 30.58 seconds.

--- a/trial.txt
+++ b/trial.txt
@@ -1,0 +1,5 @@
+before:
+    INFO:absl:start Exponential-Gap Elimination's play with multi_armed_bandit
+    INFO:absl:Exponential-Gap Elimination's play with multi_armed_bandit runs 36.91 seconds.
+    INFO:absl:start Heuristic lilUCB's play with multi_armed_bandit
+    INFO:absl:Heuristic lilUCB's play with multi_armed_bandit runs 30.58 seconds.


### PR DESCRIPTION
Earlier we were calculating the UCB for each arm index. I have changed it to use the previously calculated UCB, and update the UCB of only those arms that are pulled

before:
    INFO:absl:Heuristic lilUCB's play with multi_armed_bandit runs 30.58 seconds.
after:
    INFO:absl:Heuristic lilUCB's play with multi_armed_bandit runs 18.36 seconds.